### PR TITLE
Store the state remotely in s3

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -7,10 +7,23 @@ terraform {
       version = "5.95.0"
     }
   }
+
+  backend "s3" {
+    bucket       = "paulb-devops-toolkit-terraform-state"
+    key          = "tfstate"
+    region       = "us-east-1"
+    use_lockfile = true
+  }
 }
 
 provider "aws" {
   shared_config_files      = ["/Users/paulbenetis/.aws/config"]
   shared_credentials_files = ["/Users/paulbenetis/.aws/credentials"]
   profile                  = "default"
+
+  default_tags {
+    tags = {
+      Project = "devops-toolkit"
+    }
+  }
 }

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,0 +1,10 @@
+resource "aws_s3_bucket" "tf_state" {
+  bucket = "paulb-devops-toolkit-terraform-state"
+}
+
+resource "aws_s3_bucket_versioning" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}


### PR DESCRIPTION
- Create s3 bucket to store the state
- Setup Terraform to store the state in the bucket with lockfile enabled

This will allow the Terraform state to be stored remotely.  